### PR TITLE
cleanup: Apply consistent style and fixup to avoid semver incompatible change

### DIFF
--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -54,6 +54,28 @@ impl Expr {
             ExprKind::Normal(_) | ExprKind::String(_) | ExprKind::Symbol(_) => None,
         }
     }
+
+    //---------------------------------------------------------------------
+    // SEMVER: This methods have been replaced, remove in a future version.
+    //---------------------------------------------------------------------
+
+    #[deprecated(note = "Use Expr::try_as_normal() instead")]
+    #[allow(missing_docs)]
+    pub fn try_normal(&self) -> Option<&Normal> {
+        self.try_as_normal()
+    }
+
+    #[deprecated(note = "Use Expr::try_as_symbol() instead")]
+    #[allow(missing_docs)]
+    pub fn try_symbol(&self) -> Option<&Symbol> {
+        self.try_as_symbol()
+    }
+
+    #[deprecated(note = "Use Expr::try_as_number() instead")]
+    #[allow(missing_docs)]
+    pub fn try_number(&self) -> Option<Number> {
+        self.try_as_number()
+    }
 }
 
 //=======================================

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -55,9 +55,9 @@ impl Expr {
         }
     }
 
-    //---------------------------------------------------------------------
-    // SEMVER: This methods have been replaced, remove in a future version.
-    //---------------------------------------------------------------------
+    //---------------------------------------------------------------------------
+    // SEMVER: These methods have been replaced; remove them in a future version.
+    //---------------------------------------------------------------------------
 
     #[deprecated(note = "Use Expr::try_as_normal() instead")]
     #[allow(missing_docs)]

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -13,7 +13,9 @@ impl Expr {
         }
     }
 
-    /// If this is a [True](http://reference.wolfram.com/language/ref/True.html) or [False](http://reference.wolfram.com/language/ref/False.html) value, return that. Otherwise return None.
+    /// If this is a [`True`](http://reference.wolfram.com/language/ref/True.html)
+    /// or [`False`](http://reference.wolfram.com/language/ref/False.html) symbol,
+    /// return that. Otherwise return None.
     pub fn try_as_bool(&self) -> Option<bool> {
         let s = self.try_as_symbol()?;
         if s.as_str() == "System`True" {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -257,7 +257,10 @@ impl Expr {
     /// ```
     /// use wolfram_expr::{Expr, Symbol};
     ///
-    /// let delayed = Expr::rule(Symbol::new("Global`x"), Expr::normal(Symbol::new("System`RandomReal"), vec![]));
+    /// let delayed = Expr::rule_delayed(
+    ///     Symbol::new("Global`x"),
+    ///     Expr::normal(Symbol::new("System`RandomReal"), vec![])
+    /// );
     /// ```
     pub fn rule_delayed<LHS: Into<Expr>>(lhs: LHS, rhs: Expr) -> Expr {
         let lhs = lhs.into();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -282,23 +282,6 @@ impl Expr {
     pub fn list(elements: Vec<Expr>) -> Expr {
         Expr::normal(Symbol::new("System`List"), elements)
     }
-    /// Construct a new `Association[...]`(`<|...|>`) expression from it's elements.
-    ///
-    /// # Example
-    ///
-    /// Construct the expression `<|"a"->1, "b":>2|>`:
-    ///
-    /// ```
-    /// use wolfram_expr::Expr;
-    ///
-    /// let assoc = Expr::association(vec![
-    ///     Expr::rule(Expr::from("a"), Expr::from(1)),
-    ///     Expr::rule_delayed(Expr::from("b"), Expr::from(2)),
-    /// ]);
-    /// ```
-    pub fn association(elements: Vec<Expr>) -> Expr {
-        Expr::normal(Symbol::new("System`Association"), elements)
-    }
 }
 
 /// Wolfram Language expression variants.


### PR DESCRIPTION
This applies minor changes to the code contributed in #7, to apply consistent line wrapping, and avoid a semver-incompatible removal of methods.

@oovm Thanks again for #7! The things I'm changing in this PR were oversights on my part while reviewing your PR.