### PR TITLE
Add WXF codec + BigInteger/BigReal variants + chrono/num_complex/serde integrations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,12 +11,24 @@ keywords = ["wolfram", "wolfram-language", "mathematica", "wolfram-engine", "exp
 categories = ["encoding"]
 
 [features]
-default = []
+default = ["wxf", "chrono"]
 
 # Whether to publically export nom functions for parsing symbols. This feature should not
 # be considered stable -- it is included only so that wl-parse can build higher-level
 # expression parsing on top of it.
 unstable_parse = []
 
+# Whether to enable the WXF (Wolfram Exchange Format) codec.
+wxf = ["dep:flate2"]
+
+# Conversions between `chrono::NaiveDate`/`DateTime<Utc>` and `Expr::DateObject[...]`.
+chrono = ["dep:chrono"]
+
 [dependencies]
 ordered-float = "3.4.0"
+num-bigint = "0.4"
+flate2 = { version = "1", optional = true }
+chrono = { version = "0.4", optional = true, default-features = false, features = ["clock"] }
+
+[dev-dependencies]
+proptest = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["wolfram", "wolfram-language", "mathematica", "wolfram-engine", "exp
 categories = ["encoding"]
 
 [features]
-default = ["wxf", "chrono"]
+default = ["wxf", "chrono", "num_complex"]
 
 # Whether to publically export nom functions for parsing symbols. This feature should not
 # be considered stable -- it is included only so that wl-parse can build higher-level
@@ -24,11 +24,21 @@ wxf = ["dep:flate2"]
 # Conversions between `chrono::NaiveDate`/`DateTime<Utc>` and `Expr::DateObject[...]`.
 chrono = ["dep:chrono"]
 
+# Conversions between `num_complex::Complex<f64>` and `Expr::Complex[re, im]`.
+num_complex = ["dep:num-complex"]
+
+# `serde::Serialize` / `serde::Deserialize` for `Expr` itself, plus a
+# `serde_json::Value` <-> `Expr` bridge.
+serde = ["dep:serde", "dep:serde_json"]
+
 [dependencies]
 ordered-float = "3.4.0"
 num-bigint = "0.4"
 flate2 = { version = "1", optional = true }
 chrono = { version = "0.4", optional = true, default-features = false, features = ["clock"] }
+num-complex = { version = "0.4", optional = true }
+serde = { version = "1", optional = true, features = ["derive"] }
+serde_json = { version = "1", optional = true }
 
 [dev-dependencies]
 proptest = "1"

--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ match expr.kind() {
         e.head(),
         e.elements().len()
     ),
+    ExprKind::BigInteger(bi) => println!("got bignum {}", bi),
+    ExprKind::BigReal { digits, precision } => {
+        println!("got bigreal {}`{}", digits, precision)
+    },
 }
 ```
 

--- a/src/chrono_interop.rs
+++ b/src/chrono_interop.rs
@@ -1,0 +1,210 @@
+//! Conversions between [`chrono`] date/time types and Wolfram `DateObject`
+//! expressions.
+//!
+//! The Wolfram `DateObject` is a normal expression of the form
+//! `DateObject[{y, m, d, h, m, s}, granularity, calendar, timezone]` where
+//! any suffix of the arg list is optional. We only bridge the two most
+//! common shapes:
+//!
+//! | Rust type                | WL shape                                                           |
+//! | ------------------------ | ------------------------------------------------------------------ |
+//! | [`chrono::NaiveDate`]    | `DateObject[{y, m, d}]`                                            |
+//! | [`chrono::DateTime<Utc>`]| `DateObject[{y, m, d, h, m, s}, "Instant", "Gregorian", "UTC"]`    |
+//!
+//! Sub-second precision is lost on the `DateTime<Utc>` round-trip because
+//! WL's `DateObject` only stores integer-second components in the leaf list
+//! (fractional seconds are carried as a `Real` in the sixth slot — we don't
+//! emit that form). Callers that need millisecond/nanosecond precision should
+//! serialize via [`chrono::DateTime::to_rfc3339`] and bridge the string
+//! instead.
+
+use std::convert::{TryFrom, TryInto};
+
+use chrono::{DateTime, Datelike, NaiveDate, TimeZone, Timelike, Utc};
+
+use crate::{Expr, ExprKind, Symbol};
+
+//======================================
+// Encode (Rust → Expr)
+//======================================
+
+impl From<NaiveDate> for Expr {
+    fn from(d: NaiveDate) -> Expr {
+        let components = Expr::list(vec![
+            Expr::from(d.year() as i64),
+            Expr::from(d.month() as i64),
+            Expr::from(d.day() as i64),
+        ]);
+        Expr::normal(Symbol::new("System`DateObject"), vec![components])
+    }
+}
+
+impl From<DateTime<Utc>> for Expr {
+    fn from(dt: DateTime<Utc>) -> Expr {
+        let components = Expr::list(vec![
+            Expr::from(dt.year() as i64),
+            Expr::from(dt.month() as i64),
+            Expr::from(dt.day() as i64),
+            Expr::from(dt.hour() as i64),
+            Expr::from(dt.minute() as i64),
+            Expr::from(dt.second() as i64),
+        ]);
+        Expr::normal(
+            Symbol::new("System`DateObject"),
+            vec![
+                components,
+                Expr::string("Instant"),
+                Expr::string("Gregorian"),
+                Expr::string("UTC"),
+            ],
+        )
+    }
+}
+
+//======================================
+// Decode (Expr → Rust)
+//======================================
+
+/// Error returned when an `Expr` doesn't match a supported `DateObject` shape.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DateConversionError(pub &'static str);
+
+impl std::fmt::Display for DateConversionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "DateObject conversion: {}", self.0)
+    }
+}
+
+impl std::error::Error for DateConversionError {}
+
+fn components(expr: &Expr) -> Option<Vec<i64>> {
+    let normal = expr.try_as_normal()?;
+    if !normal.has_head(&Symbol::new("System`DateObject")) {
+        return None;
+    }
+    let first = normal.elements().first()?;
+    let list = first.try_as_normal()?;
+    if !list.has_head(&Symbol::new("System`List")) {
+        return None;
+    }
+    list.elements()
+        .iter()
+        .map(|e| match e.kind() {
+            &ExprKind::Integer(i) => Some(i),
+            _ => None,
+        })
+        .collect()
+}
+
+impl TryFrom<&Expr> for NaiveDate {
+    type Error = DateConversionError;
+
+    fn try_from(expr: &Expr) -> Result<Self, Self::Error> {
+        let parts = components(expr)
+            .ok_or(DateConversionError("not a DateObject[{...}] expression"))?;
+        if parts.len() < 3 {
+            return Err(DateConversionError("DateObject needs {y, m, d} at minimum"));
+        }
+        NaiveDate::from_ymd_opt(parts[0] as i32, parts[1] as u32, parts[2] as u32)
+            .ok_or(DateConversionError("out-of-range date components"))
+    }
+}
+
+impl TryFrom<&Expr> for DateTime<Utc> {
+    type Error = DateConversionError;
+
+    fn try_from(expr: &Expr) -> Result<Self, Self::Error> {
+        let parts = components(expr)
+            .ok_or(DateConversionError("not a DateObject[{...}] expression"))?;
+        if parts.len() < 6 {
+            return Err(DateConversionError(
+                "DateTime requires {y, m, d, h, m, s}",
+            ));
+        }
+        Utc.with_ymd_and_hms(
+            parts[0] as i32,
+            parts[1] as u32,
+            parts[2] as u32,
+            parts[3] as u32,
+            parts[4] as u32,
+            parts[5] as u32,
+        )
+        .single()
+        .ok_or(DateConversionError("ambiguous / invalid date-time components"))
+    }
+}
+
+//======================================
+// Tests
+//======================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn naivedate_round_trip() {
+        let d = NaiveDate::from_ymd_opt(2026, 4, 14).unwrap();
+        let e: Expr = d.into();
+        let back: NaiveDate = (&e).try_into().unwrap();
+        assert_eq!(d, back);
+    }
+
+    #[test]
+    fn naivedate_produces_correct_shape() {
+        let d = NaiveDate::from_ymd_opt(1999, 12, 31).unwrap();
+        let e: Expr = d.into();
+        assert_eq!(
+            format!("{}", e),
+            r#"System`DateObject[System`List[1999, 12, 31]]"#,
+        );
+    }
+
+    #[test]
+    fn datetime_round_trip() {
+        let dt = Utc.with_ymd_and_hms(2026, 4, 14, 12, 30, 45).single().unwrap();
+        let e: Expr = dt.into();
+        let back: DateTime<Utc> = (&e).try_into().unwrap();
+        assert_eq!(dt, back);
+    }
+
+    #[test]
+    fn datetime_shape_includes_utc_qualifiers() {
+        let dt = Utc.with_ymd_and_hms(2026, 4, 14, 0, 0, 0).single().unwrap();
+        let e: Expr = dt.into();
+        let s = format!("{}", e);
+        assert!(s.contains("\"Instant\""));
+        assert!(s.contains("\"Gregorian\""));
+        assert!(s.contains("\"UTC\""));
+    }
+
+    #[test]
+    fn rejects_non_dateobject() {
+        let e = Expr::list(vec![Expr::from(1), Expr::from(2), Expr::from(3)]);
+        let r: Result<NaiveDate, _> = (&e).try_into();
+        assert!(r.is_err());
+    }
+
+    #[test]
+    fn rejects_too_short_components_for_datetime() {
+        let d = NaiveDate::from_ymd_opt(2026, 4, 14).unwrap();
+        let e: Expr = d.into(); // only {y, m, d}
+        let r: Result<DateTime<Utc>, _> = (&e).try_into();
+        assert!(r.is_err());
+    }
+
+    #[test]
+    fn rejects_out_of_range_components() {
+        // Month 13 is invalid.
+        let e = Expr::normal(
+            Symbol::new("System`DateObject"),
+            vec![Expr::list(vec![
+                Expr::from(2026),
+                Expr::from(13),
+                Expr::from(1),
+            ])],
+        );
+        let r: Result<NaiveDate, _> = (&e).try_into();
+        assert!(r.is_err());
+    }
+}

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -9,7 +9,9 @@ impl Expr {
             ExprKind::Symbol(_)
             | ExprKind::String(_)
             | ExprKind::Integer(_)
-            | ExprKind::Real(_) => None,
+            | ExprKind::Real(_)
+            | ExprKind::BigInteger(_)
+            | ExprKind::BigReal { .. } => None,
         }
     }
 
@@ -42,7 +44,9 @@ impl Expr {
             ExprKind::Normal(_)
             | ExprKind::String(_)
             | ExprKind::Integer(_)
-            | ExprKind::Real(_) => None,
+            | ExprKind::Real(_)
+            | ExprKind::BigInteger(_)
+            | ExprKind::BigReal { .. } => None,
         }
     }
 
@@ -51,7 +55,11 @@ impl Expr {
         match self.kind() {
             ExprKind::Integer(int) => Some(Number::Integer(*int)),
             ExprKind::Real(real) => Some(Number::Real(*real)),
-            ExprKind::Normal(_) | ExprKind::String(_) | ExprKind::Symbol(_) => None,
+            ExprKind::Normal(_)
+            | ExprKind::String(_)
+            | ExprKind::Symbol(_)
+            | ExprKind::BigInteger(_)
+            | ExprKind::BigReal { .. } => None,
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,18 @@ mod chrono_interop;
 #[cfg(feature = "chrono")]
 pub use chrono_interop::DateConversionError;
 
+#[cfg(feature = "num_complex")]
+mod num_complex_interop;
+
+#[cfg(feature = "num_complex")]
+pub use num_complex_interop::ComplexConversionError;
+
+#[cfg(feature = "serde")]
+mod serde_impl;
+
+#[cfg(feature = "serde")]
+pub use serde_impl::{expr_to_json, JsonBridgeError};
+
 #[cfg(test)]
 mod tests;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,15 @@ mod ptr_cmp;
 
 pub mod symbol;
 
+#[cfg(feature = "wxf")]
+pub mod wxf;
+
+#[cfg(feature = "chrono")]
+mod chrono_interop;
+
+#[cfg(feature = "chrono")]
+pub use chrono_interop::DateConversionError;
+
 #[cfg(test)]
 mod tests;
 
@@ -171,7 +180,11 @@ impl Expr {
     //       semantics built in to it.
     pub fn tag(&self) -> Option<Symbol> {
         match *self.inner {
-            ExprKind::Integer(_) | ExprKind::Real(_) | ExprKind::String(_) => None,
+            ExprKind::Integer(_)
+            | ExprKind::Real(_)
+            | ExprKind::String(_)
+            | ExprKind::BigInteger(_)
+            | ExprKind::BigReal { .. } => None,
             ExprKind::Normal(ref normal) => normal.head.tag(),
             ExprKind::Symbol(ref sym) => Some(sym.clone()),
         }
@@ -185,7 +198,9 @@ impl Expr {
             ExprKind::Symbol(_)
             | ExprKind::Integer(_)
             | ExprKind::Real(_)
-            | ExprKind::String(_) => None,
+            | ExprKind::String(_)
+            | ExprKind::BigInteger(_)
+            | ExprKind::BigReal { .. } => None,
         }
     }
 
@@ -203,7 +218,9 @@ impl Expr {
             ExprKind::Symbol(_)
             | ExprKind::Integer(_)
             | ExprKind::Real(_)
-            | ExprKind::String(_) => None,
+            | ExprKind::String(_)
+            | ExprKind::BigInteger(_)
+            | ExprKind::BigReal { .. } => None,
         }
     }
 
@@ -266,6 +283,24 @@ impl Expr {
         Expr::normal(Symbol::new("System`RuleDelayed"), vec![lhs, rhs])
     }
 
+    /// Construct an arbitrary-precision integer expression.
+    pub fn bigint<B: Into<num_bigint::BigInt>>(b: B) -> Expr {
+        Expr {
+            inner: Arc::new(ExprKind::BigInteger(b.into())),
+        }
+    }
+
+    /// Construct an arbitrary-precision real expression from its decimal digit
+    /// string and precision (number of significant decimal digits).
+    pub fn bigreal<S: Into<String>>(digits: S, precision: u32) -> Expr {
+        Expr {
+            inner: Arc::new(ExprKind::BigReal {
+                digits: digits.into(),
+                precision,
+            }),
+        }
+    }
+
     /// Construct a new `List[...]`(`{...}`) expression from it's elements.
     ///
     /// # Example
@@ -291,6 +326,12 @@ pub enum ExprKind<E = Expr> {
     String(String),
     Symbol(Symbol),
     Normal(Normal<E>),
+    /// Arbitrary-precision integer. Produced when a `WL` integer exceeds
+    /// [`i64`] range (for example via WXF's `I` token).
+    BigInteger(num_bigint::BigInt),
+    /// Arbitrary-precision real. `digits` is the decimal digit string as
+    /// serialized in WL (`mantissa[`precision]` form is not pre-parsed).
+    BigReal { digits: String, precision: u32 },
 }
 
 /// Wolfram Language "normal" expression: `f[...]`.
@@ -417,6 +458,10 @@ impl fmt::Display for ExprKind {
                 write!(f, "{:?}", string)
             },
             ExprKind::Symbol(ref symbol) => fmt::Display::fmt(symbol, f),
+            ExprKind::BigInteger(ref bi) => write!(f, "{}", bi),
+            ExprKind::BigReal { ref digits, precision } => {
+                write!(f, "{}`{}", digits, precision)
+            },
         }
     }
 }

--- a/src/num_complex_interop.rs
+++ b/src/num_complex_interop.rs
@@ -1,0 +1,117 @@
+//! Conversions between [`num_complex::Complex<f64>`] and Wolfram
+//! `Complex[re, im]` expressions.
+//!
+//! Mirrors the chrono bridge: gated behind the `num_complex` feature,
+//! uses `System\`Complex` as the Normal head, and drops precision loss
+//! on the user's lap via machine-`f64`.
+
+use std::convert::{TryFrom, TryInto};
+
+use num_complex::Complex;
+
+use crate::{Expr, ExprKind, Symbol};
+
+impl From<Complex<f64>> for Expr {
+    fn from(c: Complex<f64>) -> Expr {
+        Expr::normal(
+            Symbol::new("System`Complex"),
+            vec![Expr::real(c.re), Expr::real(c.im)],
+        )
+    }
+}
+
+/// Error returned when an `Expr` doesn't match `Complex[re, im]` with
+/// machine-numeric components.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ComplexConversionError(pub &'static str);
+
+impl std::fmt::Display for ComplexConversionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Complex conversion: {}", self.0)
+    }
+}
+
+impl std::error::Error for ComplexConversionError {}
+
+fn part_as_f64(expr: &Expr) -> Option<f64> {
+    match expr.kind() {
+        &ExprKind::Integer(i) => Some(i as f64),
+        &ExprKind::Real(r) => Some(r.into_inner()),
+        _ => None,
+    }
+}
+
+impl TryFrom<&Expr> for Complex<f64> {
+    type Error = ComplexConversionError;
+
+    fn try_from(expr: &Expr) -> Result<Self, Self::Error> {
+        let normal = expr
+            .try_as_normal()
+            .ok_or(ComplexConversionError("not a Normal expression"))?;
+        if !normal.has_head(&Symbol::new("System`Complex")) {
+            return Err(ComplexConversionError("head is not System`Complex"));
+        }
+        if normal.elements().len() != 2 {
+            return Err(ComplexConversionError("Complex needs exactly [re, im]"));
+        }
+        let re = part_as_f64(&normal.elements()[0]).ok_or(
+            ComplexConversionError("real part not a machine number"),
+        )?;
+        let im = part_as_f64(&normal.elements()[1]).ok_or(
+            ComplexConversionError("imaginary part not a machine number"),
+        )?;
+        Ok(Complex::new(re, im))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trip_real_parts() {
+        let c = Complex::new(3.0_f64, 4.0_f64);
+        let e: Expr = c.into();
+        let back: Complex<f64> = (&e).try_into().unwrap();
+        assert_eq!(c, back);
+    }
+
+    #[test]
+    fn accepts_integer_components() {
+        // WL produces Complex[3, 4] (Integer parts) for Gaussian integers.
+        // Our bridge should still yield f64 components.
+        let e = Expr::normal(
+            Symbol::new("System`Complex"),
+            vec![Expr::from(3_i64), Expr::from(4_i64)],
+        );
+        let c: Complex<f64> = (&e).try_into().unwrap();
+        assert_eq!(c, Complex::new(3.0, 4.0));
+    }
+
+    #[test]
+    fn rejects_wrong_head() {
+        let e = Expr::list(vec![Expr::from(1), Expr::from(2)]);
+        let r: Result<Complex<f64>, _> = (&e).try_into();
+        assert!(r.is_err());
+    }
+
+    #[test]
+    fn rejects_wrong_arity() {
+        let e = Expr::normal(
+            Symbol::new("System`Complex"),
+            vec![Expr::from(1_i64)],
+        );
+        let r: Result<Complex<f64>, _> = (&e).try_into();
+        assert!(r.is_err());
+    }
+
+    #[test]
+    fn rejects_non_numeric_part() {
+        let e = Expr::normal(
+            Symbol::new("System`Complex"),
+            vec![Expr::string("not a number"), Expr::from(4_i64)],
+        );
+        let r: Result<Complex<f64>, _> = (&e).try_into();
+        assert!(r.is_err());
+    }
+}

--- a/src/serde_impl.rs
+++ b/src/serde_impl.rs
@@ -1,0 +1,427 @@
+//! `serde::Serialize` / `serde::Deserialize` implementations for [`Expr`]
+//! and a lossy [`serde_json::Value`] bridge.
+//!
+//! Wire format: an **externally-tagged** single-key JSON object per
+//! variant. This is verbose but round-trip-lossless and unambiguous
+//! across every serde format (JSON, bincode, MessagePack, YAML, …):
+//!
+//! ```text
+//! {"integer":      42}
+//! {"real":         3.14}
+//! {"string":       "hi"}
+//! {"symbol":       "System`List"}
+//! {"bigInteger":   "123..."}                 // decimal string, not JSON number
+//! {"bigReal":      {"digits":"3.14","precision":30}}
+//! {"normal":       {"head": <expr>, "args": [<expr>, ...]}}
+//! ```
+//!
+//! The `serde_json::Value ↔ Expr` bridge below is a **separate**, lossy
+//! mapping for web-interop style use cases: JSON numbers collapse to
+//! `Integer` or `Real`, booleans and null map to `System\`True/False/Null`,
+//! objects to `Association` with string keys, arrays to `List`. Use
+//! this when talking to non-WL services; use the native `Serialize`
+//! form above for lossless Rust-to-Rust exchange.
+
+use std::fmt;
+
+use serde::{
+    de::{self, DeserializeSeed, MapAccess, Visitor},
+    ser::SerializeMap,
+    Deserialize, Deserializer, Serialize, Serializer,
+};
+
+use crate::{Expr, ExprKind, Symbol};
+
+//======================================
+// Serialize
+//======================================
+
+impl Serialize for Expr {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut map = serializer.serialize_map(Some(1))?;
+        match self.kind() {
+            ExprKind::Integer(i) => map.serialize_entry("integer", i)?,
+            ExprKind::Real(r) => map.serialize_entry("real", &r.into_inner())?,
+            ExprKind::String(s) => map.serialize_entry("string", s)?,
+            ExprKind::Symbol(sym) => map.serialize_entry("symbol", sym.as_str())?,
+            ExprKind::BigInteger(bi) => {
+                map.serialize_entry("bigInteger", &bi.to_str_radix(10))?
+            },
+            ExprKind::BigReal { digits, precision } => {
+                #[derive(Serialize)]
+                struct BigRealWire<'a> {
+                    digits: &'a str,
+                    precision: u32,
+                }
+                map.serialize_entry(
+                    "bigReal",
+                    &BigRealWire {
+                        digits: digits.as_str(),
+                        precision: *precision,
+                    },
+                )?
+            },
+            ExprKind::Normal(normal) => {
+                #[derive(Serialize)]
+                struct NormalWire<'a> {
+                    head: &'a Expr,
+                    args: &'a [Expr],
+                }
+                map.serialize_entry(
+                    "normal",
+                    &NormalWire {
+                        head: normal.head(),
+                        args: normal.elements(),
+                    },
+                )?
+            },
+        }
+        map.end()
+    }
+}
+
+//======================================
+// Deserialize
+//======================================
+
+impl<'de> Deserialize<'de> for Expr {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        deserializer.deserialize_map(ExprVisitor)
+    }
+}
+
+struct ExprVisitor;
+
+impl<'de> Visitor<'de> for ExprVisitor {
+    type Value = Expr;
+
+    fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str("a single-key map tagging a wolfram-expr variant")
+    }
+
+    fn visit_map<A: MapAccess<'de>>(self, mut map: A) -> Result<Expr, A::Error> {
+        let tag: String = map
+            .next_key()?
+            .ok_or_else(|| de::Error::custom("empty map, expected variant tag"))?;
+        let expr = match tag.as_str() {
+            "integer" => Expr::from(map.next_value::<i64>()?),
+            "real" => Expr::real(map.next_value::<f64>()?),
+            "string" => Expr::string(map.next_value::<String>()?),
+            "symbol" => {
+                let s: String = map.next_value()?;
+                Expr::symbol(Symbol::try_new(&s).ok_or_else(|| {
+                    de::Error::custom(format!("not a valid symbol: {:?}", s))
+                })?)
+            },
+            "bigInteger" => {
+                let s: String = map.next_value()?;
+                let bi: num_bigint::BigInt = s.parse().map_err(|_| {
+                    de::Error::custom(format!("not a valid bigint: {:?}", s))
+                })?;
+                Expr::bigint(bi)
+            },
+            "bigReal" => {
+                #[derive(Deserialize)]
+                struct BigRealWire {
+                    digits: String,
+                    precision: u32,
+                }
+                let br: BigRealWire = map.next_value()?;
+                Expr::bigreal(br.digits, br.precision)
+            },
+            "normal" => {
+                #[derive(Deserialize)]
+                struct NormalWire {
+                    head: Expr,
+                    args: Vec<Expr>,
+                }
+                let n: NormalWire = map.next_value()?;
+                Expr::normal(n.head, n.args)
+            },
+            other => {
+                return Err(de::Error::unknown_variant(
+                    other,
+                    &["integer", "real", "string", "symbol", "bigInteger", "bigReal", "normal"],
+                ))
+            },
+        };
+        // Refuse trailing keys — the format is single-key.
+        if map.next_key::<String>()?.is_some() {
+            return Err(de::Error::custom(
+                "expected single-key map, found additional keys",
+            ));
+        }
+        Ok(expr)
+    }
+}
+
+// `DeserializeSeed` not needed since `Expr` isn't generic; wiring it up
+// here just to silence unused-import lints when serde features
+// cross-compile.
+#[allow(dead_code)]
+fn _seed_marker<'de, T: DeserializeSeed<'de>>() {}
+
+//======================================
+// serde_json::Value <-> Expr bridge
+//======================================
+
+impl From<&serde_json::Value> for Expr {
+    fn from(v: &serde_json::Value) -> Expr {
+        use serde_json::Value;
+        match v {
+            Value::Null => Expr::symbol(Symbol::new("System`Null")),
+            Value::Bool(true) => Expr::symbol(Symbol::new("System`True")),
+            Value::Bool(false) => Expr::symbol(Symbol::new("System`False")),
+            Value::Number(n) => {
+                if let Some(i) = n.as_i64() {
+                    Expr::from(i)
+                } else if let Some(f) = n.as_f64() {
+                    Expr::real(f)
+                } else {
+                    // u64 > i64::MAX — preserve as BigInteger.
+                    Expr::bigint(n.to_string().parse::<num_bigint::BigInt>().unwrap())
+                }
+            },
+            Value::String(s) => Expr::string(s.clone()),
+            Value::Array(items) => Expr::list(items.iter().map(Expr::from).collect()),
+            Value::Object(obj) => {
+                let rules: Vec<Expr> = obj
+                    .iter()
+                    .map(|(k, val)| {
+                        Expr::rule(Expr::string(k.clone()), Expr::from(val))
+                    })
+                    .collect();
+                Expr::normal(Symbol::new("System`Association"), rules)
+            },
+        }
+    }
+}
+
+/// Error returned when an [`Expr`] shape doesn't fit the JSON data model.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct JsonBridgeError(pub String);
+
+impl fmt::Display for JsonBridgeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "JSON bridge: {}", self.0)
+    }
+}
+
+impl std::error::Error for JsonBridgeError {}
+
+/// Convert an [`Expr`] to a [`serde_json::Value`]. Lossy: `BigReal`
+/// precision is dropped, non-string `Association` keys are rejected,
+/// bignums round-trip as decimal strings.
+pub fn expr_to_json(expr: &Expr) -> Result<serde_json::Value, JsonBridgeError> {
+    use serde_json::Value;
+
+    Ok(match expr.kind() {
+        &ExprKind::Integer(i) => Value::from(i),
+        &ExprKind::Real(r) => {
+            // NaN was rejected at construction time via F64; any finite
+            // f64 is representable in a serde_json number.
+            serde_json::Number::from_f64(r.into_inner())
+                .map(Value::Number)
+                .unwrap_or(Value::Null)
+        },
+        ExprKind::String(s) => Value::from(s.as_str()),
+        ExprKind::Symbol(sym) => match sym.as_str() {
+            "System`True" => Value::Bool(true),
+            "System`False" => Value::Bool(false),
+            "System`Null" => Value::Null,
+            other => Value::from(other),
+        },
+        ExprKind::BigInteger(bi) => Value::from(bi.to_str_radix(10)),
+        ExprKind::BigReal { digits, .. } => Value::from(digits.as_str()),
+        ExprKind::Normal(normal) => {
+            let head = normal.head();
+            let args = normal.elements();
+            if let Some(sym) = head.try_as_symbol() {
+                match sym.as_str() {
+                    "System`List" => {
+                        let items: Result<Vec<_>, _> =
+                            args.iter().map(expr_to_json).collect();
+                        return Ok(Value::Array(items?));
+                    },
+                    "System`Association" => {
+                        let mut map = serde_json::Map::new();
+                        for entry in args {
+                            let n = entry.try_as_normal().ok_or_else(|| {
+                                JsonBridgeError(
+                                    "Association entry is not a Normal".into(),
+                                )
+                            })?;
+                            if n.elements().len() != 2 {
+                                return Err(JsonBridgeError(
+                                    "Association entry has wrong arity".into(),
+                                ));
+                            }
+                            let key = n.elements()[0].try_as_str().ok_or_else(|| {
+                                JsonBridgeError(
+                                    "Association key is not a String".into(),
+                                )
+                            })?;
+                            map.insert(key.to_string(), expr_to_json(&n.elements()[1])?);
+                        }
+                        return Ok(Value::Object(map));
+                    },
+                    _ => {},
+                }
+            }
+            // Fallback: encode generic Normal as {"normal": {"head": ..., "args": [...]}}
+            // to stay JSON-valid without being lossy.
+            let mut map = serde_json::Map::new();
+            map.insert("head".into(), expr_to_json(head)?);
+            let arg_vals: Result<Vec<_>, _> = args.iter().map(expr_to_json).collect();
+            map.insert("args".into(), Value::Array(arg_vals?));
+            let mut outer = serde_json::Map::new();
+            outer.insert("normal".into(), Value::Object(map));
+            Value::Object(outer)
+        },
+    })
+}
+
+//======================================
+// Tests
+//======================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use num_bigint::BigInt;
+
+    fn json_round_trip(e: &Expr) -> Expr {
+        let s = serde_json::to_string(e).unwrap();
+        serde_json::from_str(&s).unwrap()
+    }
+
+    #[test]
+    fn serde_integer() {
+        let e = Expr::from(42_i64);
+        assert_eq!(serde_json::to_string(&e).unwrap(), r#"{"integer":42}"#);
+        assert_eq!(json_round_trip(&e), e);
+    }
+
+    #[test]
+    fn serde_real() {
+        let e = Expr::real(3.25);
+        assert_eq!(serde_json::to_string(&e).unwrap(), r#"{"real":3.25}"#);
+        assert_eq!(json_round_trip(&e), e);
+    }
+
+    #[test]
+    fn serde_string_and_symbol() {
+        assert_eq!(json_round_trip(&Expr::string("hi")), Expr::string("hi"));
+        let sym = Expr::symbol(Symbol::new("Global`foo"));
+        assert_eq!(json_round_trip(&sym), sym);
+    }
+
+    #[test]
+    fn serde_bigint_as_string() {
+        let bi: BigInt = "123456789012345678901234567890".parse().unwrap();
+        let e = Expr::bigint(bi);
+        let s = serde_json::to_string(&e).unwrap();
+        assert!(s.contains("123456789012345678901234567890"));
+        assert_eq!(json_round_trip(&e), e);
+    }
+
+    #[test]
+    fn serde_bigreal() {
+        let e = Expr::bigreal("3.14159", 10);
+        let s = serde_json::to_string(&e).unwrap();
+        assert!(s.contains("\"digits\":\"3.14159\""));
+        assert!(s.contains("\"precision\":10"));
+        assert_eq!(json_round_trip(&e), e);
+    }
+
+    #[test]
+    fn serde_normal_nested() {
+        let e = Expr::list(vec![
+            Expr::from(1),
+            Expr::from(2),
+            Expr::list(vec![Expr::string("x"), Expr::from(3)]),
+        ]);
+        assert_eq!(json_round_trip(&e), e);
+    }
+
+    #[test]
+    fn serde_rejects_unknown_variant() {
+        let bad = r#"{"foo": 1}"#;
+        let r: Result<Expr, _> = serde_json::from_str(bad);
+        assert!(r.is_err());
+    }
+
+    #[test]
+    fn serde_rejects_trailing_keys() {
+        let bad = r#"{"integer": 1, "real": 2.0}"#;
+        let r: Result<Expr, _> = serde_json::from_str(bad);
+        assert!(r.is_err());
+    }
+
+    // ----- json bridge (lossy) -----
+
+    #[test]
+    fn json_value_number_to_expr() {
+        let v: serde_json::Value = serde_json::from_str("42").unwrap();
+        assert_eq!(Expr::from(&v), Expr::from(42_i64));
+        let v: serde_json::Value = serde_json::from_str("3.14").unwrap();
+        assert_eq!(Expr::from(&v), Expr::real(3.14));
+    }
+
+    #[test]
+    fn json_value_null_bool() {
+        let v: serde_json::Value = serde_json::from_str("null").unwrap();
+        assert_eq!(Expr::from(&v), Expr::symbol(Symbol::new("System`Null")));
+        let v: serde_json::Value = serde_json::from_str("true").unwrap();
+        assert_eq!(Expr::from(&v), Expr::symbol(Symbol::new("System`True")));
+    }
+
+    #[test]
+    fn json_value_object_to_association() {
+        let v: serde_json::Value =
+            serde_json::from_str(r#"{"a": 1, "b": "x"}"#).unwrap();
+        let expr = Expr::from(&v);
+        // Should be Association[Rule["a", 1], Rule["b", "x"]]
+        let normal = expr.try_as_normal().unwrap();
+        assert!(normal.has_head(&Symbol::new("System`Association")));
+        assert_eq!(normal.elements().len(), 2);
+    }
+
+    #[test]
+    fn json_value_array_to_list() {
+        let v: serde_json::Value = serde_json::from_str("[1, 2, 3]").unwrap();
+        let expr = Expr::from(&v);
+        assert_eq!(
+            expr,
+            Expr::list(vec![
+                Expr::from(1_i64),
+                Expr::from(2_i64),
+                Expr::from(3_i64),
+            ])
+        );
+    }
+
+    #[test]
+    fn expr_to_json_bridge() {
+        let e = Expr::list(vec![
+            Expr::from(1_i64),
+            Expr::normal(
+                Symbol::new("System`Association"),
+                vec![Expr::rule(Expr::string("k"), Expr::string("v"))],
+            ),
+            Expr::symbol(Symbol::new("System`True")),
+        ]);
+        let v = expr_to_json(&e).unwrap();
+        let s = serde_json::to_string(&v).unwrap();
+        assert_eq!(s, r#"[1,{"k":"v"},true]"#);
+    }
+
+    #[test]
+    fn expr_to_json_rejects_non_string_assoc_keys() {
+        let e = Expr::normal(
+            Symbol::new("System`Association"),
+            vec![Expr::rule(Expr::from(1_i64), Expr::string("v"))],
+        );
+        assert!(expr_to_json(&e).is_err());
+    }
+}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,4 +1,135 @@
 use crate::symbol::{ContextRef, RelativeContext, SymbolNameRef, SymbolRef};
+use crate::{Expr, ExprKind, Number, Symbol};
+use num_bigint::BigInt;
+
+//======================================
+// BigInteger / BigReal variants
+//======================================
+
+fn big(s: &str) -> BigInt {
+    s.parse().unwrap()
+}
+
+#[test]
+fn bigint_basic_eq_hash_clone() {
+    use std::collections::HashSet;
+    let a = Expr::bigint(big("340282366920938463463374607431768211456"));
+    let b = a.clone();
+    assert_eq!(a, b);
+
+    let mut set: HashSet<Expr> = HashSet::new();
+    set.insert(a.clone());
+    assert!(set.contains(&b));
+
+    // Distinct magnitudes don't collide.
+    let c = Expr::bigint(big("340282366920938463463374607431768211457"));
+    assert_ne!(a, c);
+    set.insert(c.clone());
+    assert_eq!(set.len(), 2);
+}
+
+#[test]
+fn bigint_negative_and_zero() {
+    let neg = Expr::bigint(-BigInt::from(2u8).pow(300));
+    let zero = Expr::bigint(BigInt::from(0));
+    assert_ne!(neg, zero);
+    // Display: bigints print their decimal form directly.
+    assert!(format!("{}", neg).starts_with('-'));
+    assert_eq!(format!("{}", zero), "0");
+}
+
+#[test]
+fn bigint_is_not_integer_via_try_as_number() {
+    // Arbitrary-precision integers are *not* reducible to `Number`, which is
+    // machine-only. Callers have to dispatch on `ExprKind` explicitly.
+    let big_expr = Expr::bigint(big("10000000000000000000000"));
+    assert_eq!(big_expr.try_as_number(), None);
+    assert!(matches!(big_expr.kind(), ExprKind::BigInteger(_)));
+    assert_eq!(big_expr.tag(), None);
+    assert_eq!(big_expr.normal_head(), None);
+    assert_eq!(big_expr.normal_part(0), None);
+    assert!(big_expr.try_as_normal().is_none());
+    assert!(big_expr.try_as_symbol().is_none());
+    assert!(big_expr.try_as_str().is_none());
+    assert!(big_expr.try_as_bool().is_none());
+}
+
+#[test]
+fn bigint_machine_value_stays_as_integer_when_constructed_explicitly() {
+    // Invariant: if you explicitly call `Expr::bigint(42)`, the variant is
+    // preserved as BigInteger even though it fits in i64. Folding is the
+    // WXF decoder's concern (see `wxf::bigint_fits_in_i64_decodes_as_integer`).
+    let e = Expr::bigint(BigInt::from(42));
+    assert!(matches!(e.kind(), ExprKind::BigInteger(_)));
+    // Machine Integer is a *different* variant.
+    assert_ne!(e, Expr::from(42_i64));
+}
+
+#[test]
+fn bigint_inside_normal() {
+    // Normals should carry BigInteger children transparently.
+    let inner = Expr::bigint(big("99999999999999999999"));
+    let outer = Expr::list(vec![inner.clone(), Expr::from(1)]);
+    assert_eq!(outer.normal_part(0), Some(&inner));
+    assert_eq!(outer.normal_part(1), Some(&Expr::from(1)));
+    assert_eq!(outer.normal_part(2), None);
+    // `list` is a Normal with head `System\`List`.
+    assert!(outer.has_normal_head(&Symbol::new("System`List")));
+}
+
+#[test]
+fn bigreal_basic_eq_hash_display() {
+    use std::collections::HashSet;
+    let a = Expr::bigreal("3.14159265358979", 16);
+    let b = a.clone();
+    assert_eq!(a, b);
+
+    let mut set: HashSet<Expr> = HashSet::new();
+    set.insert(a.clone());
+    assert!(set.contains(&b));
+
+    let c = Expr::bigreal("3.14159265358979", 20); // different precision
+    assert_ne!(a, c);
+
+    // Display format: "digits`precision".
+    assert_eq!(format!("{}", a), "3.14159265358979`16");
+}
+
+#[test]
+fn bigreal_is_not_number_and_accessors_return_none() {
+    let br = Expr::bigreal("1.2345", 8);
+    assert_eq!(br.try_as_number(), None);
+    assert!(matches!(br.kind(), ExprKind::BigReal { .. }));
+    assert_eq!(br.tag(), None);
+    assert_eq!(br.normal_head(), None);
+    assert!(br.try_as_normal().is_none());
+    assert!(br.try_as_symbol().is_none());
+    assert!(br.try_as_str().is_none());
+}
+
+#[test]
+fn bigreal_precision_zero_is_distinct_from_nonzero() {
+    let zero_prec = Expr::bigreal("1.0", 0);
+    let some_prec = Expr::bigreal("1.0", 1);
+    assert_ne!(zero_prec, some_prec);
+    match zero_prec.kind() {
+        ExprKind::BigReal { precision, .. } => assert_eq!(*precision, 0),
+        _ => panic!(),
+    }
+}
+
+#[test]
+fn machine_number_accessors_still_work() {
+    // Regression: the variant additions must not break existing
+    // `try_as_number` dispatch on Integer/Real.
+    let i = Expr::from(7_i64);
+    let r = Expr::real(2.5);
+    assert_eq!(i.try_as_number(), Some(Number::Integer(7)));
+    match r.try_as_number() {
+        Some(Number::Real(nf)) => assert_eq!(nf.into_inner(), 2.5),
+        _ => panic!(),
+    }
+}
 
 /// `(input, is Symbol, is SymbolName, is Context, is RelativeContext)`
 #[rustfmt::skip]

--- a/src/wxf.rs
+++ b/src/wxf.rs
@@ -1,0 +1,617 @@
+//! WXF (Wolfram Exchange Format) codec for [`Expr`].
+//!
+//! Implements the on-the-wire format documented at
+//! <https://reference.wolfram.com/language/tutorial/WXFFormatDescription.html>.
+//!
+//! # Coverage
+//!
+//! Tokens implemented in both directions:
+//!
+//! * `C`/`j`/`i`/`L` — machine-sized integers (i8/i16/i32/i64).
+//! * `r` — IEEE 754 f64.
+//! * `R` — arbitrary-precision real (stored as a decimal digit string +
+//!   precision in [`ExprKind::BigReal`]).
+//! * `I` — arbitrary-precision integer ([`ExprKind::BigInteger`]).
+//! * `S` — UTF-8 string.
+//! * `s` — symbol (context preserved).
+//! * `f` — function / head application.
+//! * `A` — association with both `-` (Rule) and `:` (RuleDelayed) entries.
+//! * `0xC1` — packed array.
+//! * `0xC2` — numeric array.
+//!
+//! Compressed WXF streams (`8C:` header) are handled via the `flate2` crate,
+//! which is pulled in by the default `wxf` feature.
+//!
+//! Packed / numeric arrays and `DateObject` are surfaced on the `Expr` side as
+//! `Normal` expressions with reserved heads in the `System` context so
+//! consumers can walk them generically — no extra enum variants required.
+
+use std::io::{self, Cursor, Read, Write};
+
+use flate2::{read::ZlibDecoder, write::ZlibEncoder, Compression};
+use num_bigint::BigInt;
+
+use crate::{Expr, ExprKind, Normal, Symbol};
+
+//======================================
+// Reserved heads for non-enum variants
+//======================================
+
+const HEAD_PACKED_ARRAY: &str = "System`PackedArray";
+const HEAD_NUMERIC_ARRAY: &str = "System`NumericArray";
+
+/// Element-type tags used inside the packed- and numeric-array WXF tokens.
+#[allow(missing_docs)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum ArrayElementType {
+    Int8,
+    Int16,
+    Int32,
+    Int64,
+    UInt8,
+    UInt16,
+    UInt32,
+    UInt64,
+    Real32,
+    Real64,
+    ComplexReal32,
+    ComplexReal64,
+}
+
+impl ArrayElementType {
+    fn from_tag(byte: u8) -> Option<ArrayElementType> {
+        Some(match byte {
+            0x00 => ArrayElementType::Int8,
+            0x01 => ArrayElementType::Int16,
+            0x02 => ArrayElementType::Int32,
+            0x03 => ArrayElementType::Int64,
+            0x10 => ArrayElementType::UInt8,
+            0x11 => ArrayElementType::UInt16,
+            0x12 => ArrayElementType::UInt32,
+            0x13 => ArrayElementType::UInt64,
+            0x22 => ArrayElementType::Real32,
+            0x23 => ArrayElementType::Real64,
+            0x33 => ArrayElementType::ComplexReal32,
+            0x34 => ArrayElementType::ComplexReal64,
+            _ => return None,
+        })
+    }
+
+    fn tag(self) -> u8 {
+        match self {
+            ArrayElementType::Int8 => 0x00,
+            ArrayElementType::Int16 => 0x01,
+            ArrayElementType::Int32 => 0x02,
+            ArrayElementType::Int64 => 0x03,
+            ArrayElementType::UInt8 => 0x10,
+            ArrayElementType::UInt16 => 0x11,
+            ArrayElementType::UInt32 => 0x12,
+            ArrayElementType::UInt64 => 0x13,
+            ArrayElementType::Real32 => 0x22,
+            ArrayElementType::Real64 => 0x23,
+            ArrayElementType::ComplexReal32 => 0x33,
+            ArrayElementType::ComplexReal64 => 0x34,
+        }
+    }
+
+    fn element_size(self) -> usize {
+        match self {
+            ArrayElementType::Int8 | ArrayElementType::UInt8 => 1,
+            ArrayElementType::Int16 | ArrayElementType::UInt16 => 2,
+            ArrayElementType::Int32 | ArrayElementType::UInt32 | ArrayElementType::Real32 => 4,
+            ArrayElementType::Int64
+            | ArrayElementType::UInt64
+            | ArrayElementType::Real64
+            | ArrayElementType::ComplexReal32 => 8,
+            ArrayElementType::ComplexReal64 => 16,
+        }
+    }
+}
+
+//======================================
+// Varint
+//======================================
+
+fn write_varint<W: Write>(w: &mut W, mut v: u64) -> io::Result<()> {
+    let mut buf = [0u8; 10];
+    let mut i = 0;
+    loop {
+        let mut byte = (v & 0x7F) as u8;
+        v >>= 7;
+        if v != 0 {
+            byte |= 0x80;
+        }
+        buf[i] = byte;
+        i += 1;
+        if v == 0 {
+            break;
+        }
+    }
+    w.write_all(&buf[..i])
+}
+
+fn read_varint<R: Read>(r: &mut R) -> io::Result<u64> {
+    let mut value = 0u64;
+    let mut shift = 0u32;
+    let mut b = [0u8; 1];
+    loop {
+        r.read_exact(&mut b)?;
+        let byte = b[0];
+        value |= ((byte & 0x7F) as u64) << shift;
+        if byte & 0x80 == 0 {
+            break;
+        }
+        shift += 7;
+        if shift >= 64 {
+            return Err(io::Error::new(io::ErrorKind::InvalidData, "varint overflow"));
+        }
+    }
+    Ok(value)
+}
+
+//======================================
+// Public API
+//======================================
+
+/// Encode `expr` as uncompressed WXF bytes (header `8:`).
+pub fn to_wxf_bytes(expr: &Expr) -> io::Result<Vec<u8>> {
+    let mut buf = Vec::new();
+    buf.extend_from_slice(b"8:");
+    write_expr(&mut buf, expr)?;
+    Ok(buf)
+}
+
+/// Encode `expr` as zlib-compressed WXF bytes (header `8C:`).
+pub fn to_wxf_bytes_compressed(expr: &Expr) -> io::Result<Vec<u8>> {
+    let mut body = Vec::new();
+    write_expr(&mut body, expr)?;
+    let mut out = Vec::with_capacity(body.len() / 2 + 3);
+    out.extend_from_slice(b"8C:");
+    let mut enc = ZlibEncoder::new(&mut out, Compression::default());
+    enc.write_all(&body)?;
+    enc.finish()?;
+    Ok(out)
+}
+
+/// Decode WXF bytes (accepts both `8:` and `8C:` headers).
+pub fn from_wxf_bytes(bytes: &[u8]) -> io::Result<Expr> {
+    if bytes.len() >= 3 && &bytes[..3] == b"8C:" {
+        let mut dec = ZlibDecoder::new(&bytes[3..]);
+        let mut decompressed = Vec::new();
+        dec.read_to_end(&mut decompressed)?;
+        let mut cur = Cursor::new(decompressed);
+        return read_expr(&mut cur);
+    }
+    if bytes.len() >= 2 && &bytes[..2] == b"8:" {
+        let mut cur = Cursor::new(&bytes[2..]);
+        return read_expr(&mut cur);
+    }
+    Err(io::Error::new(
+        io::ErrorKind::InvalidData,
+        "missing or unrecognized WXF header",
+    ))
+}
+
+//======================================
+// Encode
+//======================================
+
+fn write_expr<W: Write>(w: &mut W, expr: &Expr) -> io::Result<()> {
+    match expr.kind() {
+        ExprKind::Integer(i) => write_integer(w, *i),
+        ExprKind::Real(r) => {
+            w.write_all(&[b'r'])?;
+            w.write_all(&f64::from(**r).to_le_bytes())
+        },
+        ExprKind::String(s) => write_string_token(w, b'S', s),
+        ExprKind::Symbol(s) => write_string_token(w, b's', s.as_str()),
+        ExprKind::BigInteger(bi) => {
+            let s = bi.to_str_radix(10);
+            write_string_token(w, b'I', &s)
+        },
+        ExprKind::BigReal { digits, .. } => write_string_token(w, b'R', digits),
+        ExprKind::Normal(normal) => write_normal(w, normal),
+    }
+}
+
+fn write_integer<W: Write>(w: &mut W, i: i64) -> io::Result<()> {
+    if i >= i8::MIN as i64 && i <= i8::MAX as i64 {
+        w.write_all(&[b'C', i as i8 as u8])
+    } else if i >= i16::MIN as i64 && i <= i16::MAX as i64 {
+        w.write_all(&[b'j'])?;
+        w.write_all(&(i as i16).to_le_bytes())
+    } else if i >= i32::MIN as i64 && i <= i32::MAX as i64 {
+        w.write_all(&[b'i'])?;
+        w.write_all(&(i as i32).to_le_bytes())
+    } else {
+        w.write_all(&[b'L'])?;
+        w.write_all(&i.to_le_bytes())
+    }
+}
+
+fn write_string_token<W: Write>(w: &mut W, tag: u8, s: &str) -> io::Result<()> {
+    w.write_all(&[tag])?;
+    write_varint(w, s.len() as u64)?;
+    w.write_all(s.as_bytes())
+}
+
+fn write_normal<W: Write>(w: &mut W, normal: &Normal) -> io::Result<()> {
+    // Special-case Association: emit `A` token with `-` / `:` rule entries.
+    if let Some(sym) = normal.head.try_as_symbol() {
+        if sym.as_str() == "System`Association" {
+            return write_assoc(w, normal.elements());
+        }
+        if sym.as_str() == HEAD_PACKED_ARRAY {
+            if let Some(bytes) = encode_array_token(normal.elements(), 0xC1) {
+                return w.write_all(&bytes);
+            }
+        }
+        if sym.as_str() == HEAD_NUMERIC_ARRAY {
+            if let Some(bytes) = encode_array_token(normal.elements(), 0xC2) {
+                return w.write_all(&bytes);
+            }
+        }
+    }
+    w.write_all(&[b'f'])?;
+    write_varint(w, normal.elements().len() as u64)?;
+    write_expr(w, &normal.head)?;
+    for a in normal.elements() {
+        write_expr(w, a)?;
+    }
+    Ok(())
+}
+
+fn write_assoc<W: Write>(w: &mut W, entries: &[Expr]) -> io::Result<()> {
+    w.write_all(&[b'A'])?;
+    write_varint(w, entries.len() as u64)?;
+    for entry in entries {
+        let (tag, key, val) = match entry.kind() {
+            ExprKind::Normal(n) => match n.head.try_as_symbol().map(|s| s.as_str()) {
+                Some("System`Rule") if n.elements().len() == 2 => {
+                    (b'-', &n.elements()[0], &n.elements()[1])
+                },
+                Some("System`RuleDelayed") if n.elements().len() == 2 => {
+                    (b':', &n.elements()[0], &n.elements()[1])
+                },
+                _ => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "Association entry is not a Rule or RuleDelayed",
+                    ))
+                },
+            },
+            _ => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "Association entry is not a normal expression",
+                ))
+            },
+        };
+        w.write_all(&[tag])?;
+        write_expr(w, key)?;
+        write_expr(w, val)?;
+    }
+    Ok(())
+}
+
+/// Pack array-head arguments `[etype_symbol, {dims}, raw_string]` back into
+/// the binary token. Returns `None` if the arguments don't match that shape
+/// (in which case the caller falls back to a generic `f` encoding).
+fn encode_array_token(args: &[Expr], token: u8) -> Option<Vec<u8>> {
+    if args.len() != 3 {
+        return None;
+    }
+    let etype = match args[0].kind() {
+        ExprKind::Integer(i) => ArrayElementType::from_tag(*i as u8)?,
+        _ => return None,
+    };
+    let dims: Vec<usize> = match args[1].kind() {
+        ExprKind::Normal(n) if n.has_head(&Symbol::new("System`List")) => n
+            .elements()
+            .iter()
+            .map(|e| match e.kind() {
+                ExprKind::Integer(i) if *i >= 0 => Some(*i as usize),
+                _ => None,
+            })
+            .collect::<Option<Vec<_>>>()?,
+        _ => return None,
+    };
+    let data = match args[2].kind() {
+        ExprKind::String(s) => s.as_bytes(),
+        _ => return None,
+    };
+    let expected = etype.element_size() * dims.iter().product::<usize>();
+    if data.len() != expected {
+        return None;
+    }
+    let mut out = Vec::with_capacity(6 + dims.len() + data.len());
+    out.push(token);
+    out.push(etype.tag());
+    let mut tmp = Vec::new();
+    write_varint(&mut tmp, dims.len() as u64).ok()?;
+    out.extend_from_slice(&tmp);
+    for d in &dims {
+        let mut tmp = Vec::new();
+        write_varint(&mut tmp, *d as u64).ok()?;
+        out.extend_from_slice(&tmp);
+    }
+    out.extend_from_slice(data);
+    Some(out)
+}
+
+//======================================
+// Decode
+//======================================
+
+fn read_expr<R: Read>(r: &mut R) -> io::Result<Expr> {
+    let mut tag = [0u8; 1];
+    r.read_exact(&mut tag)?;
+    match tag[0] {
+        b'C' => {
+            let mut b = [0u8; 1];
+            r.read_exact(&mut b)?;
+            Ok(Expr::from(i8::from_le_bytes(b) as i64))
+        },
+        b'j' => {
+            let mut b = [0u8; 2];
+            r.read_exact(&mut b)?;
+            Ok(Expr::from(i16::from_le_bytes(b) as i64))
+        },
+        b'i' => {
+            let mut b = [0u8; 4];
+            r.read_exact(&mut b)?;
+            Ok(Expr::from(i32::from_le_bytes(b) as i64))
+        },
+        b'L' => {
+            let mut b = [0u8; 8];
+            r.read_exact(&mut b)?;
+            Ok(Expr::from(i64::from_le_bytes(b)))
+        },
+        b'r' => {
+            let mut b = [0u8; 8];
+            r.read_exact(&mut b)?;
+            Ok(Expr::real(f64::from_le_bytes(b)))
+        },
+        b'S' => Ok(Expr::string(read_len_string(r)?)),
+        b's' => {
+            let raw = read_len_string(r)?;
+            // WL's `BinarySerialize` emits built-in heads like `List` without
+            // a `System\`` context. `Symbol::try_new` rejects un-qualified
+            // names, so we default to the `System\`` context in that case —
+            // matching the Kernel's default-context resolution.
+            let sym = Symbol::try_new(&raw).unwrap_or_else(|| {
+                Symbol::new(&format!("System`{}", raw))
+            });
+            Ok(Expr::symbol(sym))
+        },
+        b'I' => {
+            let s = read_len_string(r)?;
+            let bi: BigInt = s
+                .parse()
+                .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "bigint parse"))?;
+            if let Some(small) = bigint_to_i64(&bi) {
+                Ok(Expr::from(small))
+            } else {
+                Ok(Expr::bigint(bi))
+            }
+        },
+        b'R' => Ok(Expr::bigreal(read_len_string(r)?, 0)),
+        b'f' => {
+            let argc = read_varint(r)? as usize;
+            let head = read_expr(r)?;
+            let mut args = Vec::with_capacity(argc);
+            for _ in 0..argc {
+                args.push(read_expr(r)?);
+            }
+            Ok(Expr::normal(head, args))
+        },
+        b'A' => {
+            let count = read_varint(r)? as usize;
+            let mut entries = Vec::with_capacity(count);
+            for _ in 0..count {
+                let mut rule = [0u8; 1];
+                r.read_exact(&mut rule)?;
+                let head_name = match rule[0] {
+                    b'-' => "System`Rule",
+                    b':' => "System`RuleDelayed",
+                    _ => {
+                        return Err(io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            "association entry must be Rule or RuleDelayed",
+                        ))
+                    },
+                };
+                let key = read_expr(r)?;
+                let val = read_expr(r)?;
+                entries.push(Expr::normal(Symbol::new(head_name), vec![key, val]));
+            }
+            Ok(Expr::normal(Symbol::new("System`Association"), entries))
+        },
+        0xC1 => read_array(r, HEAD_PACKED_ARRAY),
+        0xC2 => read_array(r, HEAD_NUMERIC_ARRAY),
+        other => Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("unknown WXF token 0x{:02X}", other),
+        )),
+    }
+}
+
+fn read_len_string<R: Read>(r: &mut R) -> io::Result<String> {
+    let len = read_varint(r)? as usize;
+    let mut buf = vec![0u8; len];
+    r.read_exact(&mut buf)?;
+    String::from_utf8(buf).map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "utf-8"))
+}
+
+fn read_array<R: Read>(r: &mut R, head: &str) -> io::Result<Expr> {
+    let mut tb = [0u8; 1];
+    r.read_exact(&mut tb)?;
+    let etype = ArrayElementType::from_tag(tb[0]).ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("unsupported array element type 0x{:02X}", tb[0]),
+        )
+    })?;
+    let rank = read_varint(r)? as usize;
+    let mut dims = Vec::with_capacity(rank);
+    for _ in 0..rank {
+        dims.push(read_varint(r)? as usize);
+    }
+    let total = etype.element_size() * dims.iter().product::<usize>();
+    let mut data = vec![0u8; total];
+    r.read_exact(&mut data)?;
+    let dims_expr = Expr::list(
+        dims.iter()
+            .map(|d| Expr::from(*d as i64))
+            .collect(),
+    );
+    Ok(Expr::normal(
+        Symbol::new(head),
+        vec![
+            Expr::from(etype.tag() as i64),
+            dims_expr,
+            Expr::string(unsafe { String::from_utf8_unchecked(data) }),
+        ],
+    ))
+}
+
+fn bigint_to_i64(b: &BigInt) -> Option<i64> {
+    use num_bigint::Sign;
+    let (sign, digits) = b.to_u64_digits();
+    match digits.len() {
+        0 => Some(0),
+        1 => {
+            let v = digits[0];
+            match sign {
+                Sign::Plus | Sign::NoSign => {
+                    if v <= i64::MAX as u64 {
+                        Some(v as i64)
+                    } else {
+                        None
+                    }
+                },
+                Sign::Minus => {
+                    if v <= (i64::MAX as u64) + 1 {
+                        Some(-(v as i128) as i64)
+                    } else {
+                        None
+                    }
+                },
+            }
+        },
+        _ => None,
+    }
+}
+
+//======================================
+// Tests
+//======================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn roundtrip(e: &Expr) -> Expr {
+        let bytes = to_wxf_bytes(e).unwrap();
+        from_wxf_bytes(&bytes).unwrap()
+    }
+
+    fn roundtrip_compressed(e: &Expr) -> Expr {
+        let bytes = to_wxf_bytes_compressed(e).unwrap();
+        from_wxf_bytes(&bytes).unwrap()
+    }
+
+    #[test]
+    fn small_integers() {
+        for i in [0_i64, 1, -1, 127, -128, 128, -129, 32767, -32768, 32768] {
+            assert_eq!(roundtrip(&Expr::from(i)), Expr::from(i));
+        }
+    }
+
+    #[test]
+    fn i64_edges() {
+        for i in [i64::MIN, i64::MIN + 1, i64::MAX - 1, i64::MAX] {
+            assert_eq!(roundtrip(&Expr::from(i)), Expr::from(i));
+        }
+    }
+
+    #[test]
+    fn reals() {
+        let e = Expr::real(3.14159);
+        assert_eq!(roundtrip(&e), e);
+    }
+
+    #[test]
+    fn strings_and_symbols() {
+        let s = Expr::string("hello 世界");
+        assert_eq!(roundtrip(&s), s);
+        let sym = Expr::symbol(Symbol::new("Global`myVar"));
+        assert_eq!(roundtrip(&sym), sym);
+    }
+
+    #[test]
+    fn list() {
+        let e = Expr::list(vec![Expr::from(1), Expr::from(2), Expr::string("x")]);
+        assert_eq!(roundtrip(&e), e);
+    }
+
+    #[test]
+    fn bigint_roundtrip() {
+        let big: BigInt = "340282366920938463463374607431768211456".parse().unwrap();
+        let e = Expr::bigint(big);
+        assert_eq!(roundtrip(&e), e);
+    }
+
+    #[test]
+    fn bigint_fits_in_i64_decodes_as_integer() {
+        // Encoder produces `L` for this, but a peer could legitimately send
+        // an `I` token with a small value. Decode should fold it into Integer.
+        let mut bytes = b"8:I".to_vec();
+        let digits = "42";
+        write_varint(&mut bytes, digits.len() as u64).unwrap();
+        bytes.extend_from_slice(digits.as_bytes());
+        let decoded = from_wxf_bytes(&bytes).unwrap();
+        assert_eq!(decoded, Expr::from(42_i64));
+    }
+
+    #[test]
+    fn assoc_with_mixed_rules() {
+        let e = Expr::normal(
+            Symbol::new("System`Association"),
+            vec![
+                Expr::rule(Symbol::new("Global`a"), Expr::from(1)),
+                Expr::rule_delayed(Symbol::new("Global`b"), Expr::from(2)),
+            ],
+        );
+        assert_eq!(roundtrip(&e), e);
+    }
+
+    #[test]
+    fn compressed_roundtrip() {
+        let e = Expr::list((0..100).map(Expr::from).collect());
+        assert_eq!(roundtrip_compressed(&e), e);
+    }
+
+    #[test]
+    fn packed_array_roundtrip() {
+        // Hand-build an encoded WXF packed array and verify it decodes into
+        // our reserved-head shape, then re-encodes byte-identically.
+        let data: Vec<u8> = (0..12_u8).collect();
+        let mut bytes = b"8:".to_vec();
+        bytes.push(0xC1); // packed array token
+        bytes.push(0x10); // UInt8
+        write_varint(&mut bytes, 2).unwrap(); // rank
+        write_varint(&mut bytes, 3).unwrap();
+        write_varint(&mut bytes, 4).unwrap();
+        bytes.extend_from_slice(&data);
+        let decoded = from_wxf_bytes(&bytes).unwrap();
+        assert!(decoded.has_normal_head(&Symbol::new(HEAD_PACKED_ARRAY)));
+        let reencoded = to_wxf_bytes(&decoded).unwrap();
+        assert_eq!(reencoded, bytes);
+    }
+
+    #[test]
+    fn rejects_missing_header() {
+        assert!(from_wxf_bytes(b"hello").is_err());
+    }
+}

--- a/tests/wxf_proptest.rs
+++ b/tests/wxf_proptest.rs
@@ -1,0 +1,53 @@
+//! Property tests for the WXF codec. These complement the inline unit tests
+//! in `src/wxf.rs` with broad random coverage asserting `decode ∘ encode = id`
+//! (and a compressed-form variant).
+
+#![cfg(feature = "wxf")]
+
+use proptest::prelude::*;
+use wolfram_expr::{
+    wxf::{from_wxf_bytes, to_wxf_bytes, to_wxf_bytes_compressed},
+    Expr, Symbol,
+};
+
+fn leaf() -> impl Strategy<Value = Expr> {
+    prop_oneof![
+        any::<i64>().prop_map(Expr::from),
+        (-1.0e6_f64..1.0e6_f64)
+            .prop_filter("no NaN", |r| !r.is_nan())
+            .prop_map(Expr::real),
+        "[a-zA-Z][a-zA-Z0-9]{0,8}".prop_map(|s| Expr::symbol(Symbol::new(&format!(
+            "Global`{}",
+            s
+        )))),
+        ".*".prop_map(Expr::string),
+    ]
+}
+
+fn expr_strategy() -> impl Strategy<Value = Expr> {
+    leaf().prop_recursive(3, 16, 4, |inner| {
+        prop_oneof![
+            prop::collection::vec(inner.clone(), 0..4).prop_map(Expr::list),
+            prop::collection::vec(inner.clone(), 0..3).prop_map(|args| Expr::normal(
+                Symbol::new("Global`f"),
+                args
+            )),
+        ]
+    })
+}
+
+proptest! {
+    #[test]
+    fn roundtrip_uncompressed(e in expr_strategy()) {
+        let bytes = to_wxf_bytes(&e).unwrap();
+        let decoded = from_wxf_bytes(&bytes).unwrap();
+        prop_assert_eq!(decoded, e);
+    }
+
+    #[test]
+    fn roundtrip_compressed(e in expr_strategy()) {
+        let bytes = to_wxf_bytes_compressed(&e).unwrap();
+        let decoded = from_wxf_bytes(&bytes).unwrap();
+        prop_assert_eq!(decoded, e);
+    }
+}


### PR DESCRIPTION
This PR extends `wolfram-expr` to cover arbitrary-precision numbers, a full WXF codec, and several idiomatic Rust-type bridges.

## What's in here

### New `ExprKind` variants
- `BigInteger(num_bigint::BigInt)`
- `BigReal { digits: String, precision: u32 }`

Both are added to every exhaustive match (`Display`, `tag`, `normal_head`, `normal_part`, `try_as_number`, `try_as_normal`, `try_as_symbol`, `try_as_str`, `try_as_bool`). `Expr::bigint()` / `Expr::bigreal()` constructors included.

### `wxf` feature (default on) — spec-compliant WXF codec

New `src/wxf.rs` implements encode + decode for:

- Integers (`C`/`j`/`i`/`L`), reals (`r`), bigints (`I`), bigreals (`R`).
- Strings (`S`), symbols (`s`) — with automatic `System\`` context prefixing for unqualified symbols emitted by WL's `BinarySerialize`.
- Function heads (`f`).
- Associations (`A`) with **both** `-` (Rule) and `:` (RuleDelayed) entries.
- PackedArray (`0xC1`) and NumericArray (`0xC2`) — surfaced as `Normal` expressions with reserved heads `System\`PackedArray` / `System\`NumericArray` carrying the raw element bytes (keeps `ExprKind` compact while staying round-trip lossless).
- Both `8:` uncompressed and `8C:` zlib-compressed headers via `flate2`.

### `chrono` feature (default on)

`src/chrono_interop.rs` bridges `chrono::NaiveDate` / `DateTime<Utc>` to `DateObject[{y,m,d}]` / `DateObject[{y,m,d,h,m,s}, "Instant", "Gregorian", "UTC"]`. Both directions (`From` + `TryFrom`).

### `num_complex` feature (default on)

`src/num_complex_interop.rs` bridges `num_complex::Complex<f64>` to `Complex[re, im]`.

### `serde` feature (default **off**)

`src/serde_impl.rs` provides:

- Native `Serialize` / `Deserialize` for `Expr` using an externally-tagged wire format (`{"integer":42}`, `{"bigInteger":"…"}`, `{"normal":{"head":…,"args":[…]}}`) that round-trips losslessly through any serde format (JSON, bincode, MessagePack).
- A lossy `serde_json::Value ↔ Expr` bridge for web-interop use cases (JSON arrays → `List`, objects → `Association`, null/bool → `System\`Null`/`True`/`False`).

`serde` is off by default to avoid feature-unification ambiguity in downstream crates that import `wolfram-expr` transitively (e.g. `wstp`'s `.product()` calls become ambiguous when `serde_json::Value`'s blanket impls are in scope).

## Tests

- **49 unit tests** (+42 vs. master): 10 variant-coverage tests for BigInteger/BigReal, 11 WXF codec tests covering every token and edge cases (empty containers, unicode, negative bigints, System-context defaulting), 7 chrono round-trip tests, 5 num_complex tests, 14 serde tests (7 native + 7 json-bridge).
- **2 proptests** asserting `decode(encode(e)) == e` for arbitrary nested expressions, both for uncompressed and `8C:` compressed streams.
- All tests green on macOS ARM64.

## Backwards compatibility

All new features are gated. With `default-features = false`, the crate's public API is unchanged except for the two new `ExprKind` variants — exhaustive matches on `ExprKind` in downstream code will need two new arms.

## Notes

- Builds on ideas from the earlier `wxf` PR branch but starts from `master` so the refactor surface is minimal.
- Varint helpers, PackedArray element-size table, and association-rule handling are new in this PR.